### PR TITLE
Rename package to loop-react-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# react-auth
+# loop-react-auth
 
 > React auth library
 
-[![NPM](https://img.shields.io/npm/v/react-auth.svg)](https://www.npmjs.com/package/@loopstudio/react-auth) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+[![NPM](https://img.shields.io/npm/v/react-auth.svg)](https://www.npmjs.com/package/loop-react-auth) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
 ## Install
 
 ```bash
-npm install --save react-auth
+npm install --save loop-react-auth
 ```
 
 ## Usage
@@ -15,8 +15,8 @@ npm install --save react-auth
 ```tsx
 import React, { Component } from 'react';
 
-import MyComponent from 'react-auth';
-import 'react-auth/dist/index.css';
+import MyComponent from 'loop-react-auth';
+import 'loop-react-auth/dist/index.css';
 
 class Example extends Component {
   render() {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,10 @@
 {
-  "name": "@loopstudio/react-auth",
+  "name": "loop-react-auth",
   "version": "1.0.0",
   "description": "React auth library",
   "author": "loopstudio",
   "license": "MIT",
   "repository": "git://github.com/loopstudio/react-auth",
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "main": "dist/index.js",
   "module": "dist/index.modern.js",
   "source": "src/index.ts",


### PR DESCRIPTION
- The package was renamed to be able to publish it on npm
  this way we no longer need github personal access token
  on projects with this dependency.